### PR TITLE
fix: stub generation now detects static files in public/ directory

### DIFF
--- a/docs/stub-pages.md
+++ b/docs/stub-pages.md
@@ -1,0 +1,45 @@
+# Stub Page Generation
+
+This site automatically creates stub pages for internal links that point to non-existent content.
+
+## How it works
+
+1. **Link Detection**: The system scans all blog posts and project pages for internal markdown links
+2. **Missing Page Identification**: Compares found links against existing pages
+3. **Stub Generation**: Creates placeholder pages for missing links with appropriate backlinks
+4. **Build Integration**: Runs automatically before each build
+
+## Generated Stub Structure
+
+Each stub page includes:
+- A clear title derived from the URL path
+- Indication that it's a placeholder page  
+- **Complete backlinks** showing which pages reference it and what link text was used
+- Proper categorization by content type (Articles vs Projects)
+
+## File Locations
+
+- **Project stubs**: `projects/{slug}.md`
+- **Blog stubs**: `src/content/blog/{slug}.md` (with proper frontmatter)
+
+## Exclusions
+
+The system automatically skips:
+- Image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.svg`)
+- Document files (`.pdf`, `.zip`)
+- Web assets (`.css`, `.js`, `.json`, `.xml`)
+- External links (starting with `http` or `mailto:`)
+
+## Usage
+
+### Manual Generation
+```bash
+npm run generate-stubs
+```
+
+### Automatic Generation (during build)
+```bash  
+npm run build  # Includes stub generation
+```
+
+The stub generation is integrated into the build process and will run automatically during deployment.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "node scripts/generate-stubs.js && astro check && astro build",
+    "generate-stubs": "node scripts/generate-stubs.js",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/scripts/generate-stubs.js
+++ b/scripts/generate-stubs.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import { createStubPages } from '../src/utils/stub-pages.js';
+
+console.log('Generating stub pages for non-existent links...');
+
+try {
+  createStubPages();
+  console.log('Stub page generation completed successfully.');
+  process.exit(0);
+} catch (error) {
+  console.error('Error generating stub pages:', error);
+  process.exit(1);
+}

--- a/src/utils/backlinks.js
+++ b/src/utils/backlinks.js
@@ -1,0 +1,195 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Extract internal links from markdown content
+ */
+function extractInternalLinks(content, sourcePath, sourceTitle, sourceType) {
+  const links = [];
+  
+  // Match markdown links [text](url) where url is internal (starts with /)
+  const markdownLinkPattern = /\[([^\]]*)\]\(([^)]*)\)/g;
+  let match;
+  
+  while ((match = markdownLinkPattern.exec(content)) !== null) {
+    const text = match[1];
+    const url = match[2];
+    
+    // Only process internal links (starting with / or relative paths)
+    if (url.startsWith('/') || (!url.startsWith('http') && !url.startsWith('mailto:'))) {
+      // Normalize URL to always start with /
+      const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
+      
+      links.push({
+        text,
+        url: normalizedUrl,
+        source: sourcePath,
+        sourceTitle,
+        sourceType
+      });
+    }
+  }
+  
+  return links;
+}
+
+/**
+ * Extract title from markdown frontmatter or filename
+ */
+function extractTitle(content, filename) {
+  const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (frontmatterMatch) {
+    const titleMatch = frontmatterMatch[1].match(/title:\s*["']([^"']+)["']/);
+    if (titleMatch) {
+      return titleMatch[1];
+    }
+  }
+  
+  // Fall back to filename without extension
+  return filename.replace(/\.md$/, '').replace(/-/g, ' ');
+}
+
+/**
+ * Build backlinks data structure
+ */
+export function buildBacklinks() {
+  const backlinks = {};
+  const projectRoot = process.cwd();
+  
+  // Process blog posts
+  const blogDir = path.join(projectRoot, 'src/content/blog');
+  if (fs.existsSync(blogDir)) {
+    const blogFiles = fs.readdirSync(blogDir).filter(file => file.endsWith('.md'));
+    
+    blogFiles.forEach(file => {
+      const filePath = path.join(blogDir, file);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const title = extractTitle(content, file);
+      const blogUrl = `/blog/${file.replace('.md', '')}/`;
+      
+      const links = extractInternalLinks(content, blogUrl, title, 'blog');
+      
+      links.forEach(link => {
+        // Normalize target URLs for consistent matching
+        let targetUrl = link.url;
+        if (targetUrl.endsWith('/')) {
+          targetUrl = targetUrl.slice(0, -1);
+        }
+        
+        if (!backlinks[targetUrl]) {
+          backlinks[targetUrl] = [];
+        }
+        
+        backlinks[targetUrl].push(link);
+      });
+    });
+  }
+  
+  // Process project files
+  const projectsDir = path.join(projectRoot, 'projects');
+  if (fs.existsSync(projectsDir)) {
+    const projectFiles = fs.readdirSync(projectsDir)
+      .filter(file => file.endsWith('.md') && file !== 'README.md');
+    
+    projectFiles.forEach(file => {
+      const filePath = path.join(projectsDir, file);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const title = extractTitle(content, file);
+      const projectUrl = `/projects/${file.replace('.md', '')}/`;
+      
+      const links = extractInternalLinks(content, projectUrl, title, 'project');
+      
+      links.forEach(link => {
+        // Normalize target URLs for consistent matching
+        let targetUrl = link.url;
+        if (targetUrl.endsWith('/')) {
+          targetUrl = targetUrl.slice(0, -1);
+        }
+        
+        if (!backlinks[targetUrl]) {
+          backlinks[targetUrl] = [];
+        }
+        
+        backlinks[targetUrl].push(link);
+      });
+    });
+  }
+  
+  return backlinks;
+}
+
+/**
+ * Generate backlinks HTML for a specific page
+ */
+export function generateBacklinksHTML(pagePath, backlinksData) {
+  // Normalize the page path for consistent matching
+  let normalizedPath = pagePath;
+  if (normalizedPath.endsWith('/')) {
+    normalizedPath = normalizedPath.slice(0, -1);
+  }
+  
+  const pageBacklinks = backlinksData[normalizedPath] || [];
+  
+  if (pageBacklinks.length === 0) {
+    return '';
+  }
+  
+  let html = '<section class="backlinks">\n';
+  html += '<h2>Referenced by</h2>\n';
+  html += '<ul class="backlinks-list">\n';
+  
+  pageBacklinks.forEach(link => {
+    const typeLabel = link.sourceType === 'blog' ? 'Article' : 'Project';
+    html += `  <li><a href="${link.source}">${link.sourceTitle}</a> <span class="backlink-type">(${typeLabel})</span></li>\n`;
+  });
+  
+  html += '</ul>\n';
+  html += '</section>';
+  
+  return html;
+}
+
+/**
+ * Generate CSS for backlinks styling
+ */
+export function getBacklinksCSS() {
+  return `
+.backlinks {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+}
+
+.backlinks h2 {
+  font-size: 1.3em;
+  margin-bottom: 1rem;
+  color: var(--text-primary);
+  font-weight: 400;
+}
+
+.backlinks-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.backlinks-list li {
+  margin-bottom: 0.5rem;
+  font-size: 0.95em;
+}
+
+.backlinks-list a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.backlinks-list a:hover {
+  text-decoration: underline;
+}
+
+.backlink-type {
+  color: var(--text-tertiary);
+  font-size: 0.85em;
+  font-style: italic;
+}`;
+}

--- a/src/utils/stub-pages.js
+++ b/src/utils/stub-pages.js
@@ -1,0 +1,238 @@
+import fs from 'fs';
+import path from 'path';
+import { buildBacklinks } from './backlinks.js';
+
+/**
+ * Recursively scan public directory for static pages
+ */
+function addStaticPages(dir, basePath, existingPages) {
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const urlPath = basePath + '/' + entry.name;
+      
+      if (entry.isDirectory()) {
+        // Recursively scan subdirectories
+        addStaticPages(fullPath, urlPath, existingPages);
+        
+        // If directory contains index.html, add the directory path as a page
+        const indexPath = path.join(fullPath, 'index.html');
+        if (fs.existsSync(indexPath)) {
+          existingPages.add(urlPath);
+        }
+      } else if (entry.name === 'index.html') {
+        // index.html files are served at their directory path
+        existingPages.add(basePath || '/');
+      } else if (entry.name.endsWith('.html')) {
+        // Other HTML files are served with their filename (minus extension)
+        const name = entry.name.replace('.html', '');
+        existingPages.add(basePath + '/' + name);
+      }
+    }
+  } catch (error) {
+    // Silently ignore directories we can't read
+    console.warn(`Warning: Could not read directory ${dir}`);
+  }
+}
+
+/**
+ * Get all existing page paths in the site
+ */
+function getExistingPages() {
+  const existingPages = new Set();
+  const projectRoot = process.cwd();
+  
+  // Add root pages
+  existingPages.add('/');
+  existingPages.add('/blog');
+  existingPages.add('/projects');
+  existingPages.add('/tags');
+  
+  // Add blog posts
+  const blogDir = path.join(projectRoot, 'src/content/blog');
+  if (fs.existsSync(blogDir)) {
+    const blogFiles = fs.readdirSync(blogDir).filter(file => file.endsWith('.md'));
+    blogFiles.forEach(file => {
+      const slug = file.replace('.md', '');
+      existingPages.add(`/blog/${slug}`);
+    });
+  }
+  
+  // Add project pages
+  const projectsDir = path.join(projectRoot, 'projects');
+  if (fs.existsSync(projectsDir)) {
+    const projectFiles = fs.readdirSync(projectsDir)
+      .filter(file => file.endsWith('.md') && file !== 'README.md');
+    projectFiles.forEach(file => {
+      const slug = file.replace('.md', '');
+      existingPages.add(`/projects/${slug}`);
+    });
+  }
+  
+  // Add static pages from public directory
+  const publicDir = path.join(projectRoot, 'public');
+  if (fs.existsSync(publicDir)) {
+    addStaticPages(publicDir, '', existingPages);
+  }
+  
+  return existingPages;
+}
+
+/**
+ * Identify links pointing to non-existent pages
+ */
+export function findMissingPages() {
+  const backlinksData = buildBacklinks();
+  const existingPages = getExistingPages();
+  const missingPages = [];
+  
+  // Check each target URL in the backlinks data
+  for (const [targetPath, links] of Object.entries(backlinksData)) {
+    // Normalize the path for comparison
+    let normalizedPath = targetPath;
+    if (!normalizedPath.startsWith('/')) {
+      normalizedPath = `/${normalizedPath}`;
+    }
+    // Remove trailing slash for consistency
+    if (normalizedPath.endsWith('/') && normalizedPath !== '/') {
+      normalizedPath = normalizedPath.slice(0, -1);
+    }
+    
+    // Skip image files and other resources that shouldn't be pages
+    const skipExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.pdf', '.zip', '.css', '.js', '.json', '.xml'];
+    const shouldSkip = skipExtensions.some(ext => normalizedPath.toLowerCase().endsWith(ext));
+    
+    // Check if this page exists
+    if (!shouldSkip && !existingPages.has(normalizedPath) && !existingPages.has(`${normalizedPath}/`)) {
+      // Generate a title from the path
+      const pathParts = normalizedPath.split('/').filter(Boolean);
+      const title = pathParts.length > 0 
+        ? pathParts[pathParts.length - 1].replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
+        : 'Untitled Page';
+      
+      missingPages.push({
+        path: normalizedPath,
+        title,
+        links
+      });
+    }
+  }
+  
+  return missingPages;
+}
+
+/**
+ * Generate the content for a stub page
+ */
+export function generateStubPageContent(stubPage) {
+  const { title, links } = stubPage;
+  
+  // Group links by source type
+  const projectLinks = links.filter(link => link.sourceType === 'project');
+  const blogLinks = links.filter(link => link.sourceType === 'blog');
+  
+  let content = `# ${title}
+
+*This page doesn't exist yet, but it's referenced by other content on this site.*
+
+## Referenced by
+
+`;
+
+  if (projectLinks.length > 0) {
+    content += `### Projects\n\n`;
+    projectLinks.forEach(link => {
+      content += `- [${link.sourceTitle}](${link.source}) mentions "${link.text}"\n`;
+    });
+    content += '\n';
+  }
+  
+  if (blogLinks.length > 0) {
+    content += `### Articles\n\n`;
+    blogLinks.forEach(link => {
+      content += `- [${link.sourceTitle}](${link.source}) mentions "${link.text}"\n`;
+    });
+    content += '\n';
+  }
+  
+  content += `---
+
+*This is a stub page. The content referenced here may be added in the future.*`;
+  
+  return content;
+}
+
+/**
+ * Create stub page files
+ */
+export function createStubPages() {
+  const missingPages = findMissingPages();
+  const projectRoot = process.cwd();
+  
+  if (missingPages.length === 0) {
+    console.log('No missing pages found - all internal links point to existing content.');
+    return;
+  }
+  
+  console.log(`Found ${missingPages.length} missing pages. Creating stub pages...`);
+  
+  missingPages.forEach(stubPage => {
+    const { path: pagePath } = stubPage;
+    const pathParts = pagePath.split('/').filter(Boolean);
+    
+    if (pathParts.length === 0) return; // Skip root page
+    
+    // Determine where to create the stub page
+    let targetDir;
+    let filename;
+    
+    if (pathParts[0] === 'projects' && pathParts.length === 2) {
+      // This is a project page
+      targetDir = path.join(projectRoot, 'projects');
+      filename = `${pathParts[1]}.md`;
+    } else if (pathParts[0] === 'blog' && pathParts.length === 2) {
+      // This is a blog post - we'll create a stub in the content collection
+      targetDir = path.join(projectRoot, 'src/content/blog');
+      filename = `${pathParts[1]}.md`;
+    } else {
+      // For other paths, create in projects directory as a fallback
+      targetDir = path.join(projectRoot, 'projects');
+      filename = `${pathParts[pathParts.length - 1]}.md`;
+    }
+    
+    // Ensure directory exists
+    if (!fs.existsSync(targetDir)) {
+      fs.mkdirSync(targetDir, { recursive: true });
+    }
+    
+    const filePath = path.join(targetDir, filename);
+    
+    // Only create if file doesn't already exist
+    if (!fs.existsSync(filePath)) {
+      const content = generateStubPageContent(stubPage);
+      
+      // Add appropriate frontmatter for blog posts
+      if (pathParts[0] === 'blog') {
+        const frontmatter = `---
+title: "${stubPage.title}"
+date: ${new Date().toISOString().split('T')[0]}
+description: "Stub page for ${stubPage.title}"
+tags: ["stub"]
+---
+
+`;
+        fs.writeFileSync(filePath, frontmatter + content, 'utf-8');
+      } else {
+        fs.writeFileSync(filePath, content, 'utf-8');
+      }
+      
+      console.log(`Created stub page: ${filePath} for path ${pagePath}`);
+    } else {
+      console.log(`Stub page already exists: ${filePath}`);
+    }
+  });
+  
+  console.log(`Stub page generation complete. Created pages for ${missingPages.length} missing links.`);
+}


### PR DESCRIPTION
Fixes issue where stub generation incorrectly created stubs for existing static content.

## Summary
- Add addStaticPages() function to scan public/ directory for HTML files
- Fixes issue where /websim wasn’t detected as existing page
- Update package.json to include generate-stubs script and build integration
- Now correctly handles index.html files served at directory paths
- Prevents incorrect stub creation for existing static content

## Test Plan
- [x] Verify /websim is now detected as existing page
- [x] Confirm no incorrect stubs are created
- [x] Test build integration works correctly
- [x] Validate nested HTML files are detected

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)