### PR TITLE
feat: Add ProseMirror inline editing with GitHub authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,14 @@
       "dependencies": {
         "@astrojs/check": "^0.3.0",
         "astro": "^4.0.0",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-markdown": "^1.13.2",
+        "prosemirror-model": "^1.25.2",
+        "prosemirror-schema-basic": "^1.2.4",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-view": "^1.40.1",
         "typescript": "^5.0.0"
       },
       "devDependencies": {
@@ -1761,6 +1769,22 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -1769,6 +1793,12 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -3488,6 +3518,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz",
@@ -3608,6 +3647,35 @@
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
         "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -3844,6 +3912,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4579,6 +4653,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
@@ -4840,6 +4920,108 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
+      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
+      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.2.tgz",
+      "integrity": "sha512-BVypCAJ4SL6jOiTsDffP3Wp6wD69lRhI4zg/iT8JXjp3ccZFiq5WyguxvMKmdKFC3prhaig7wSr8dneDToHE1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
+      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.4.tgz",
+      "integrity": "sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.40.1.tgz",
+      "integrity": "sha512-pbwUjt3G7TlsQQHDiYSupWBhJswpLVB09xXm1YiJPdkjkh9Pe7Y51XdLh5VWIZmROLY8UpUpG03lkdhm9lzIBA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -5203,6 +5385,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5540,6 +5728,12 @@
       "dependencies": {
         "semver": "^7.3.8"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.8.0",
@@ -6075,6 +6269,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
     "node_modules/web-namespaces": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
   "dependencies": {
     "@astrojs/check": "^0.3.0",
     "astro": "^4.0.0",
+    "prosemirror-commands": "^1.7.1",
+    "prosemirror-history": "^1.4.1",
+    "prosemirror-keymap": "^1.2.3",
+    "prosemirror-markdown": "^1.13.2",
+    "prosemirror-model": "^1.25.2",
+    "prosemirror-schema-basic": "^1.2.4",
+    "prosemirror-state": "^1.4.3",
+    "prosemirror-view": "^1.40.1",
     "typescript": "^5.0.0"
   },
   "devDependencies": {

--- a/src/components/EditButton.astro
+++ b/src/components/EditButton.astro
@@ -1,0 +1,88 @@
+---
+export interface Props {
+  filePath: string;
+  className?: string;
+}
+
+const { filePath, className = '' } = Astro.props;
+---
+
+<button 
+  class={`edit-btn ${className}`}
+  data-file-path={filePath}
+  id="edit-content-btn"
+  style="display: none;"
+>
+  Edit
+</button>
+
+<script>
+import { authService } from '../services/auth';
+
+function initEditButton() {
+  const editBtn = document.getElementById('edit-content-btn');
+  
+  if (!editBtn) return;
+
+  // Show button only if user has GitHub token
+  if (authService.hasToken()) {
+    editBtn.style.display = 'inline-block';
+  }
+
+  editBtn.addEventListener('click', async () => {
+    const filePath = editBtn.getAttribute('data-file-path');
+    if (!filePath) return;
+
+    // Validate token before opening editor
+    const isValid = await authService.validateToken();
+    if (!isValid) {
+      alert('GitHub token is invalid or expired. Please check your token in the footer settings.');
+      return;
+    }
+
+    // Open editor modal
+    if ((window as any).editorManager) {
+      await (window as any).editorManager.open(filePath);
+    }
+  });
+}
+
+// Initialize when DOM is loaded
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initEditButton);
+} else {
+  initEditButton();
+}
+</script>
+
+<style>
+  .edit-btn {
+    background: var(--accent);
+    color: white;
+    border: 1px solid var(--accent);
+    padding: 0.3rem 0.8rem;
+    border-radius: 4px;
+    font-size: 0.85em;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    margin-left: 1rem;
+  }
+
+  .edit-btn:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+  }
+
+  .edit-btn:active {
+    transform: translateY(1px);
+  }
+
+  @media (max-width: 768px) {
+    .edit-btn {
+      margin-left: 0;
+      margin-top: 0.5rem;
+      display: block;
+      width: fit-content;
+    }
+  }
+</style>

--- a/src/components/Editor.astro
+++ b/src/components/Editor.astro
@@ -1,0 +1,281 @@
+---
+export interface Props {
+  content: string;
+  filePath: string;
+  onSave?: (content: string) => void;
+}
+---
+
+<div id="editor-modal" class="editor-modal">
+  <div class="editor-container">
+    <div class="editor-header">
+      <h3>Edit Content</h3>
+      <div class="editor-actions">
+        <button id="save-btn" class="btn btn-primary">Save</button>
+        <button id="cancel-btn" class="btn btn-secondary">Cancel</button>
+      </div>
+    </div>
+    <div id="editor-content" class="editor-content"></div>
+    <div class="editor-status" id="editor-status"></div>
+  </div>
+</div>
+
+<script>
+import { EditorState } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { keymap } from 'prosemirror-keymap';
+import { history, undo, redo } from 'prosemirror-history';
+import { baseKeymap } from 'prosemirror-commands';
+import { defaultMarkdownParser, defaultMarkdownSerializer } from 'prosemirror-markdown';
+import { githubService } from '../services/github';
+
+class EditorManager {
+  private view: EditorView | null = null;
+  private originalContent: string = '';
+  private filePath: string = '';
+  private sha: string = '';
+
+  init(content: string, filePath: string) {
+    this.originalContent = content;
+    this.filePath = filePath;
+    this.setupEditor();
+    this.setupEventListeners();
+  }
+
+  private setupEditor() {
+    const container = document.getElementById('editor-content');
+    if (!container) return;
+
+    // Parse markdown to ProseMirror doc
+    const doc = defaultMarkdownParser.parse(this.originalContent);
+    
+    const state = EditorState.create({
+      doc,
+      plugins: [
+        history(),
+        keymap({
+          "Mod-z": undo,
+          "Mod-y": redo,
+          "Mod-Shift-z": redo
+        }),
+        keymap(baseKeymap)
+      ]
+    });
+
+    this.view = new EditorView(container, {
+      state,
+      dispatchTransaction: (transaction) => {
+        const newState = this.view!.state.apply(transaction);
+        this.view!.updateState(newState);
+      }
+    });
+  }
+
+  private setupEventListeners() {
+    const modal = document.getElementById('editor-modal');
+    const saveBtn = document.getElementById('save-btn');
+    const cancelBtn = document.getElementById('cancel-btn');
+
+    saveBtn?.addEventListener('click', () => this.save());
+    cancelBtn?.addEventListener('click', () => this.close());
+    
+    modal?.addEventListener('click', (e) => {
+      if (e.target === modal) this.close();
+    });
+  }
+
+  private async save() {
+    if (!this.view) return;
+
+    const statusEl = document.getElementById('editor-status');
+    if (statusEl) statusEl.textContent = 'Saving...';
+
+    try {
+      // Convert ProseMirror doc back to markdown
+      const markdown = defaultMarkdownSerializer.serialize(this.view.state.doc);
+      
+      // Update file via GitHub API
+      await githubService.updateFile(
+        this.filePath,
+        markdown,
+        this.sha,
+        `Update ${this.filePath} via inline editor`
+      );
+
+      if (statusEl) statusEl.textContent = 'Saved successfully!';
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
+    } catch (error) {
+      console.error('Save failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      if (statusEl) statusEl.textContent = `Error: ${message}`;
+    }
+  }
+
+  private close() {
+    const modal = document.getElementById('editor-modal');
+    if (modal) modal.style.display = 'none';
+    
+    if (this.view) {
+      this.view.destroy();
+      this.view = null;
+    }
+  }
+
+  async open(filePath: string) {
+    try {
+      const statusEl = document.getElementById('editor-status');
+      if (statusEl) statusEl.textContent = 'Loading...';
+
+      // Load file content from GitHub
+      const fileData = await githubService.getFile(filePath);
+      this.originalContent = fileData.content;
+      this.filePath = filePath;
+      this.sha = fileData.sha;
+
+      this.setupEditor();
+      
+      const modal = document.getElementById('editor-modal');
+      if (modal) modal.style.display = 'flex';
+      
+      if (statusEl) statusEl.textContent = '';
+    } catch (error) {
+      console.error('Failed to load content:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      const statusEl = document.getElementById('editor-status');
+      if (statusEl) statusEl.textContent = `Error: ${message}`;
+    }
+  }
+}
+
+// Global editor manager
+(window as any).editorManager = new EditorManager();
+</script>
+
+<style>
+  .editor-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  }
+
+  .editor-container {
+    background: var(--background);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    width: 90%;
+    max-width: 1000px;
+    max-height: 80%;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  }
+
+  .editor-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--background-subtle);
+  }
+
+  .editor-header h3 {
+    margin: 0;
+    font-size: 1.2em;
+    color: var(--text-primary);
+  }
+
+  .editor-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .btn {
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: all 0.15s ease;
+  }
+
+  .btn-primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+
+  .btn-primary:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+  }
+
+  .btn-secondary {
+    background: var(--background);
+    color: var(--text-primary);
+  }
+
+  .btn-secondary:hover {
+    background: var(--background-subtle);
+  }
+
+  .editor-content {
+    flex: 1;
+    padding: 1rem;
+    overflow-y: auto;
+    min-height: 400px;
+  }
+
+  .editor-content :global(.ProseMirror) {
+    outline: none;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    min-height: 300px;
+    font-family: Georgia, serif;
+    line-height: 1.6;
+  }
+
+  .editor-content :global(.ProseMirror p) {
+    margin: 1em 0;
+  }
+
+  .editor-content :global(.ProseMirror h1),
+  .editor-content :global(.ProseMirror h2),
+  .editor-content :global(.ProseMirror h3) {
+    font-weight: 400;
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+  }
+
+  .editor-status {
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--border);
+    background: var(--background-subtle);
+    color: var(--text-secondary);
+    font-size: 0.9em;
+    min-height: 1.2em;
+  }
+
+  @media (max-width: 768px) {
+    .editor-container {
+      width: 95%;
+      max-height: 90%;
+    }
+    
+    .editor-header {
+      flex-direction: column;
+      gap: 1rem;
+      text-align: center;
+    }
+  }
+</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,289 @@
+---
+---
+
+<footer class="site-footer">
+  <div class="footer-content">
+    <div class="footer-section">
+      <p>&copy; 2024 Christopher de Beer. All rights reserved.</p>
+    </div>
+    
+    <div class="footer-section">
+      <details class="github-setup">
+        <summary>GitHub Edit Setup</summary>
+        <div class="setup-content">
+          <p>To enable inline editing, provide your GitHub personal access token:</p>
+          <div class="token-form">
+            <input 
+              type="password" 
+              id="github-token-input" 
+              placeholder="Enter GitHub token..."
+              class="token-input"
+            />
+            <div class="token-actions">
+              <button id="save-token-btn" class="btn btn-primary">Save</button>
+              <button id="test-token-btn" class="btn btn-secondary">Test</button>
+              <button id="clear-token-btn" class="btn btn-danger">Clear</button>
+            </div>
+          </div>
+          <div id="token-status" class="token-status"></div>
+          <div class="token-help">
+            <p><small>
+              Required permissions: <code>repo</code> scope for private repositories or <code>public_repo</code> for public repositories.
+              <br>
+              <a href="https://github.com/settings/tokens" target="_blank" rel="noopener">Create token</a>
+            </small></p>
+          </div>
+        </div>
+      </details>
+    </div>
+  </div>
+</footer>
+
+<script>
+import { authService } from '../services/auth';
+
+function initTokenSetup() {
+  const tokenInput = document.getElementById('github-token-input') as HTMLInputElement;
+  const saveBtn = document.getElementById('save-token-btn');
+  const testBtn = document.getElementById('test-token-btn');
+  const clearBtn = document.getElementById('clear-token-btn');
+  const statusEl = document.getElementById('token-status');
+
+  if (!tokenInput || !saveBtn || !testBtn || !clearBtn || !statusEl) return;
+
+  // Load existing token (masked)
+  if (authService.hasToken()) {
+    tokenInput.placeholder = '••••••••••••••••';
+    statusEl.textContent = 'Token saved';
+    statusEl.className = 'token-status success';
+  }
+
+  saveBtn.addEventListener('click', async () => {
+    const token = tokenInput.value.trim();
+    if (!token) {
+      statusEl.textContent = 'Please enter a token';
+      statusEl.className = 'token-status error';
+      return;
+    }
+
+    authService.setToken(token);
+    
+    // Test the token
+    statusEl.textContent = 'Testing token...';
+    statusEl.className = 'token-status';
+    
+    const isValid = await authService.validateToken();
+    if (isValid) {
+      statusEl.textContent = 'Token saved and validated!';
+      statusEl.className = 'token-status success';
+      tokenInput.value = '';
+      tokenInput.placeholder = '••••••••••••••••';
+      
+      // Refresh page to show edit buttons
+      setTimeout(() => window.location.reload(), 1000);
+    } else {
+      statusEl.textContent = 'Invalid token. Please check your token and permissions.';
+      statusEl.className = 'token-status error';
+      authService.clearToken();
+    }
+  });
+
+  testBtn.addEventListener('click', async () => {
+    if (!authService.hasToken()) {
+      statusEl.textContent = 'No token saved to test';
+      statusEl.className = 'token-status error';
+      return;
+    }
+
+    statusEl.textContent = 'Testing token...';
+    statusEl.className = 'token-status';
+    
+    const isValid = await authService.validateToken();
+    statusEl.textContent = isValid ? 'Token is valid!' : 'Token is invalid or expired';
+    statusEl.className = `token-status ${isValid ? 'success' : 'error'}`;
+  });
+
+  clearBtn.addEventListener('click', () => {
+    authService.clearToken();
+    tokenInput.value = '';
+    tokenInput.placeholder = 'Enter GitHub token...';
+    statusEl.textContent = 'Token cleared';
+    statusEl.className = 'token-status';
+    
+    // Refresh page to hide edit buttons
+    setTimeout(() => window.location.reload(), 1000);
+  });
+}
+
+// Initialize when DOM is loaded
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initTokenSetup);
+} else {
+  initTokenSetup();
+}
+</script>
+
+<style>
+  .site-footer {
+    margin-top: 4rem;
+    padding: 2rem 0;
+    border-top: 1px solid var(--border);
+    background: var(--background-subtle);
+  }
+
+  .footer-content {
+    max-width: 65ch;
+    margin: 0 auto;
+    padding: 0 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 2rem;
+  }
+
+  .footer-section {
+    flex: 1;
+  }
+
+  .footer-section:first-child {
+    flex: 0 0 auto;
+  }
+
+  .github-setup {
+    text-align: right;
+  }
+
+  .github-setup summary {
+    cursor: pointer;
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+  }
+
+  .github-setup summary:hover {
+    color: var(--accent);
+  }
+
+  .setup-content {
+    margin-top: 1rem;
+    text-align: left;
+  }
+
+  .setup-content p {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+  }
+
+  .token-form {
+    margin-bottom: 1rem;
+  }
+
+  .token-input {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 0.9em;
+    margin-bottom: 0.5rem;
+    font-family: monospace;
+  }
+
+  .token-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .token-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .btn {
+    padding: 0.4rem 0.8rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8em;
+    transition: all 0.15s ease;
+  }
+
+  .btn-primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+
+  .btn-primary:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+  }
+
+  .btn-secondary {
+    background: var(--background);
+    color: var(--text-primary);
+  }
+
+  .btn-secondary:hover {
+    background: var(--background-subtle);
+  }
+
+  .btn-danger {
+    background: #dc3545;
+    color: white;
+    border-color: #dc3545;
+  }
+
+  .btn-danger:hover {
+    background: #c82333;
+    border-color: #c82333;
+  }
+
+  .token-status {
+    font-size: 0.8em;
+    margin: 0.5rem 0;
+    color: var(--text-secondary);
+  }
+
+  .token-status.success {
+    color: #28a745;
+  }
+
+  .token-status.error {
+    color: #dc3545;
+  }
+
+  .token-help {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-light);
+  }
+
+  .token-help a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .token-help a:hover {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 768px) {
+    .footer-content {
+      flex-direction: column;
+      text-align: center;
+    }
+
+    .github-setup {
+      text-align: center;
+    }
+
+    .setup-content {
+      text-align: left;
+    }
+
+    .token-actions {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,9 @@
 /// <reference path="../.astro/types.d.ts" />
+
+declare global {
+  interface Window {
+    editorManager: {
+      open: (filePath: string) => Promise<void>;
+    };
+  }
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import Footer from '../components/Footer.astro';
+
 export interface Props {
 	title: string;
 }
@@ -18,6 +20,7 @@ const { title } = Astro.props;
 	</head>
 	<body>
 		<slot />
+		<Footer />
 	</body>
 </html>
 <style is:global>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,6 +1,8 @@
 ---
 import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
+import EditButton from '../../components/EditButton.astro';
+import Editor from '../../components/Editor.astro';
 import { buildBacklinks, generateBacklinksHTML } from '../../utils/backlinks.ts';
 
 export async function getStaticPaths() {
@@ -19,6 +21,9 @@ const { title, date, tags } = post.data;
 const backlinksData = buildBacklinks();
 const currentPagePath = `/blog/${post.slug}`;
 const backlinksHTML = generateBacklinksHTML(currentPagePath, backlinksData);
+
+// File path for editing
+const filePath = `src/content/blog/${post.slug}.md`;
 ---
 
 <Layout title={`${title} - Christopher de Beer`}>
@@ -26,7 +31,10 @@ const backlinksHTML = generateBacklinksHTML(currentPagePath, backlinksData);
     <div class="content-container">
       <article class="post">
         <header class="post-header">
-          <h1>{title}</h1>
+          <h1>
+            {title}
+            <EditButton filePath={filePath} />
+          </h1>
           <div class="post-meta">
             <time datetime={date.toISOString()}>
               {date.toLocaleDateString('en-US', { 
@@ -60,6 +68,9 @@ const backlinksHTML = generateBacklinksHTML(currentPagePath, backlinksData);
       </article>
     </div>
   </main>
+  
+  <!-- Editor modal -->
+  <Editor content="" filePath={filePath} />
 </Layout>
 
 <style>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,5 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import EditButton from '../../components/EditButton.astro';
+import Editor from '../../components/Editor.astro';
 import fs from 'fs';
 import path from 'path';
 import { buildBacklinks, generateBacklinksHTML } from '../../utils/backlinks.ts';
@@ -54,6 +56,9 @@ function markdownToHtml(markdown: string): string {
 }
 
 const htmlContent = markdownToHtml(content);
+
+// File path for editing
+const filePath = `projects/${slug}.md`;
 ---
 
 <Layout title={`${title} - Projects - Christopher de Beer`}>
@@ -63,7 +68,10 @@ const htmlContent = markdownToHtml(content);
         <nav class="breadcrumb">
           <a href="/">Home</a> → <a href="/projects/">Projects</a> → <span>{title}</span>
         </nav>
-        <h1>{title}</h1>
+        <h1>
+          {title}
+          <EditButton filePath={filePath} />
+        </h1>
       </header>
       
       <div class="project-content" set:html={htmlContent} />
@@ -78,6 +86,9 @@ const htmlContent = markdownToHtml(content);
       </footer>
     </article>
   </main>
+  
+  <!-- Editor modal -->
+  <Editor content="" filePath={filePath} />
 </Layout>
 
 <style>

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,52 @@
+const STORAGE_KEY = 'github_token';
+
+export class AuthService {
+  private token: string | null = null;
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      this.token = localStorage.getItem(STORAGE_KEY);
+    }
+  }
+
+  setToken(token: string): void {
+    if (typeof window !== 'undefined') {
+      this.token = token;
+      localStorage.setItem(STORAGE_KEY, token);
+    }
+  }
+
+  getToken(): string | null {
+    return this.token;
+  }
+
+  hasToken(): boolean {
+    return this.token !== null && this.token.trim() !== '';
+  }
+
+  clearToken(): void {
+    if (typeof window !== 'undefined') {
+      this.token = null;
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  async validateToken(): Promise<boolean> {
+    if (!this.hasToken()) return false;
+
+    try {
+      const response = await fetch('https://api.github.com/user', {
+        headers: {
+          'Authorization': `token ${this.token}`,
+          'Accept': 'application/vnd.github.v3+json'
+        }
+      });
+      return response.ok;
+    } catch (error) {
+      console.error('Token validation failed:', error);
+      return false;
+    }
+  }
+}
+
+export const authService = new AuthService();

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,0 +1,82 @@
+import { authService } from './auth';
+
+export interface GitHubFileResponse {
+  content: string;
+  sha: string;
+  path: string;
+}
+
+export class GitHubService {
+  private readonly owner = 'christopherdebeer';
+  private readonly repo = 'christopherdebeer.github.com';
+  private readonly baseUrl = 'https://api.github.com';
+
+  private async makeRequest(endpoint: string, options: RequestInit = {}): Promise<Response> {
+    const token = authService.getToken();
+    if (!token) {
+      throw new Error('No GitHub token available');
+    }
+
+    const url = `${this.baseUrl}${endpoint}`;
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        'Authorization': `token ${token}`,
+        'Accept': 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`GitHub API error: ${response.status} ${error}`);
+    }
+
+    return response;
+  }
+
+  async getFile(path: string): Promise<GitHubFileResponse> {
+    const response = await this.makeRequest(`/repos/${this.owner}/${this.repo}/contents/${path}`);
+    const data = await response.json();
+    
+    if (data.type !== 'file') {
+      throw new Error('Path does not point to a file');
+    }
+
+    const content = atob(data.content);
+    return {
+      content,
+      sha: data.sha,
+      path: data.path,
+    };
+  }
+
+  async updateFile(path: string, content: string, sha: string, message: string): Promise<void> {
+    // Properly encode UTF-8 content to base64
+    const encodedContent = btoa(new TextEncoder().encode(content).reduce((data, byte) => {
+      return data + String.fromCharCode(byte);
+    }, ''));
+    
+    const body = {
+      message: message,
+      content: encodedContent,
+      sha: sha,
+    };
+
+    await this.makeRequest(`/repos/${this.owner}/${this.repo}/contents/${path}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    });
+  }
+
+  getBlogFilePath(slug: string): string {
+    return `src/content/blog/${slug}.md`;
+  }
+
+  getProjectFilePath(slug: string): string {
+    return `projects/${slug}.md`;
+  }
+}
+
+export const githubService = new GitHubService();


### PR DESCRIPTION
## Summary

- Implement ProseMirror inline editing for blog posts and project pages
- Add GitHub token authentication with localStorage storage
- Create footer UI for token setup and management
- Integrate edit buttons that appear when authenticated
- Handle markdown conversion and GitHub API operations

## Test Plan

- [ ] Verify build process completes successfully
- [ ] Test GitHub token setup in footer
- [ ] Confirm edit buttons appear when token is configured
- [ ] Test inline editing functionality on blog posts
- [ ] Test inline editing functionality on project pages
- [ ] Verify content saves correctly to GitHub
- [ ] Ensure site rebuilds automatically after changes

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #15