### PR TITLE
Add eruda dev console

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ const { title } = Astro.props;
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
+		<script is:inline src="https://cdnjs.cloudflare.com/ajax/libs/eruda/3.0.1/eruda.min.js" onload="eruda.init()"></script>
 		<title>{title}</title>
 	</head>
 	<body>


### PR DESCRIPTION
Adds eruda development console to all pages via global Layout.astro file. The script loads from CDN before other bundled JavaScript and initializes automatically.

Closes #19

Generated with [Claude Code](https://claude.ai/code)