### PR TITLE
Add consistent breadcrumb navigation to blog pages

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -31,6 +31,9 @@ const filePath = `src/content/blog/${post.slug}.md`;
     <div class="content-container">
       <article class="post">
         <header class="post-header">
+          <nav class="breadcrumb">
+            <a href="/">Home</a> → <a href="/blog/">Blog</a> → <span>{title}</span>
+          </nav>
           <h1>
             {title}
             <EditButton filePath={filePath} />
@@ -80,9 +83,24 @@ const filePath = `src/content/blog/${post.slug}.md`;
 
   .post-header {
     margin-bottom: 3rem;
-    text-align: center;
     border-bottom: 1px solid var(--border);
     padding-bottom: 2rem;
+  }
+
+  .breadcrumb {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+    text-align: center;
+  }
+
+  .breadcrumb a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .breadcrumb a:hover {
+    text-decoration: underline;
   }
 
   .post-header h1 {
@@ -91,6 +109,7 @@ const filePath = `src/content/blog/${post.slug}.md`;
     color: var(--text-primary);
     line-height: 1.2;
     font-weight: 400;
+    text-align: center;
   }
 
   .post-meta {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -13,6 +13,9 @@ const sortedPosts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.
       <header>
         <h1>Blog</h1>
         <p>Thoughts, projects, and explorations</p>
+        <nav class="breadcrumb">
+          <a href="/">Home</a> → <span>Blog</span>
+        </nav>
       </header>
       
       <section class="posts">
@@ -63,8 +66,22 @@ const sortedPosts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.
   header p {
     font-size: 1.1em;
     color: var(--text-secondary);
-    margin: 0;
+    margin: 0 0 1rem 0;
     font-style: italic;
+  }
+
+  .breadcrumb {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+  }
+
+  .breadcrumb a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .breadcrumb a:hover {
+    text-decoration: underline;
   }
 
   .posts {


### PR DESCRIPTION
Fixes #21

Added consistent breadcrumb navigation throughout the website:

- Blog index page: `Home → Blog`
- Individual blog posts: `Home → Blog → Post Title`
- Maintained consistent styling with existing breadcrumbs

Users can now easily navigate back to homepage from all blog pages.

Generated with [Claude Code](https://claude.ai/code)