### PR TITLE
Implement smoother inline editing experience

### DIFF
--- a/src/components/EditButton.astro
+++ b/src/components/EditButton.astro
@@ -33,12 +33,21 @@ function initEditButton() {
     editBtn.style.display = 'inline-block';
     
     // Auto-open editor when edit mode is active
+    // Check if inline editor is available, otherwise use modal
     setTimeout(async () => {
       const filePath = editBtn.getAttribute('data-file-path');
-      if (filePath && (window as any).editorManager) {
+      const inlineEditorAvailable = (window as any).inlineEditorManager;
+      
+      if (filePath) {
         const isValid = await authService.validateToken();
         if (isValid) {
-          await (window as any).editorManager.open(filePath);
+          if (inlineEditorAvailable) {
+            // Inline editor will be initialized by the page script
+            return;
+          } else if ((window as any).editorManager) {
+            // Fallback to modal editor
+            await (window as any).editorManager.open(filePath);
+          }
         }
       }
     }, 100); // Small delay to ensure DOM is ready

--- a/src/components/EditButton.astro
+++ b/src/components/EditButton.astro
@@ -24,9 +24,24 @@ function initEditButton() {
   
   if (!editBtn) return;
 
-  // Show button only if user has GitHub token
-  if (authService.hasToken()) {
+  // Check for edit mode in URL
+  const urlParams = new URLSearchParams(window.location.search);
+  const editMode = urlParams.get('edit') === 'true';
+  
+  // Show button if user has GitHub token AND edit mode is enabled
+  if (authService.hasToken() && editMode) {
     editBtn.style.display = 'inline-block';
+    
+    // Auto-open editor when edit mode is active
+    setTimeout(async () => {
+      const filePath = editBtn.getAttribute('data-file-path');
+      if (filePath && (window as any).editorManager) {
+        const isValid = await authService.validateToken();
+        if (isValid) {
+          await (window as any).editorManager.open(filePath);
+        }
+      }
+    }, 100); // Small delay to ensure DOM is ready
   }
 
   editBtn.addEventListener('click', async () => {

--- a/src/components/Editor.astro
+++ b/src/components/Editor.astro
@@ -135,6 +135,7 @@ class EditorManager {
       this.sha = fileData.sha;
 
       this.setupEditor();
+      this.setupEventListeners();
       
       const modal = document.getElementById('editor-modal');
       if (modal) modal.style.display = 'flex';

--- a/src/components/InlineEditor.astro
+++ b/src/components/InlineEditor.astro
@@ -1,10 +1,7 @@
 ---
 export interface Props {
   filePath: string;
-  initialContent?: string;
 }
-
-const { filePath, initialContent = '' } = Astro.props;
 ---
 
 <div id="inline-editor" class="inline-editor" style="display: none;">

--- a/src/components/InlineEditor.astro
+++ b/src/components/InlineEditor.astro
@@ -1,0 +1,293 @@
+---
+export interface Props {
+  filePath: string;
+  initialContent?: string;
+}
+
+const { filePath, initialContent = '' } = Astro.props;
+---
+
+<div id="inline-editor" class="inline-editor" style="display: none;">
+  <div class="editor-header">
+    <div class="editor-status" id="inline-editor-status"></div>
+    <div class="editor-actions">
+      <button id="inline-save-btn" class="btn btn-primary">Save</button>
+      <button id="inline-cancel-btn" class="btn btn-secondary">Cancel</button>
+    </div>
+  </div>
+  <div id="inline-editor-content" class="editor-content"></div>
+</div>
+
+<script>
+import { EditorState } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { keymap } from 'prosemirror-keymap';
+import { history, undo, redo } from 'prosemirror-history';
+import { baseKeymap } from 'prosemirror-commands';
+import { defaultMarkdownParser, defaultMarkdownSerializer } from 'prosemirror-markdown';
+import { githubService } from '../services/github';
+
+class InlineEditorManager {
+  private view: EditorView | null = null;
+  private originalContent: string = '';
+  private filePath: string = '';
+  private sha: string = '';
+  private originalElement: HTMLElement | null = null;
+
+  async init(filePath: string) {
+    this.filePath = filePath;
+    
+    try {
+      const statusEl = document.getElementById('inline-editor-status');
+      if (statusEl) statusEl.textContent = 'Loading...';
+
+      // Load file content from GitHub
+      const fileData = await githubService.getFile(filePath);
+      this.originalContent = fileData.content;
+      this.sha = fileData.sha;
+
+      this.setupEditor();
+      this.setupEventListeners();
+      this.show();
+      
+      if (statusEl) statusEl.textContent = '';
+    } catch (error) {
+      console.error('Failed to load content:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      const statusEl = document.getElementById('inline-editor-status');
+      if (statusEl) statusEl.textContent = `Error: ${message}`;
+    }
+  }
+
+  private setupEditor() {
+    const container = document.getElementById('inline-editor-content');
+    if (!container) return;
+
+    // Parse markdown to ProseMirror doc
+    const doc = defaultMarkdownParser.parse(this.originalContent);
+    
+    const state = EditorState.create({
+      doc,
+      plugins: [
+        history(),
+        keymap({
+          "Mod-z": undo,
+          "Mod-y": redo,
+          "Mod-Shift-z": redo,
+          "Mod-s": () => {
+            this.save();
+            return true;
+          },
+          "Escape": () => {
+            this.cancel();
+            return true;
+          }
+        }),
+        keymap(baseKeymap)
+      ]
+    });
+
+    this.view = new EditorView(container, {
+      state,
+      dispatchTransaction: (transaction) => {
+        const newState = this.view!.state.apply(transaction);
+        this.view!.updateState(newState);
+      }
+    });
+  }
+
+  private setupEventListeners() {
+    const saveBtn = document.getElementById('inline-save-btn');
+    const cancelBtn = document.getElementById('inline-cancel-btn');
+
+    saveBtn?.addEventListener('click', () => this.save());
+    cancelBtn?.addEventListener('click', () => this.cancel());
+  }
+
+  private show() {
+    // Hide original content
+    const postContent = document.querySelector('.post-content');
+    const projectContent = document.querySelector('.project-content');
+    const contentElement = postContent || projectContent;
+    
+    if (contentElement) {
+      this.originalElement = contentElement as HTMLElement;
+      this.originalElement.style.display = 'none';
+    }
+
+    // Show inline editor
+    const editor = document.getElementById('inline-editor');
+    if (editor) {
+      editor.style.display = 'block';
+    }
+
+    // Focus the editor
+    if (this.view) {
+      this.view.focus();
+    }
+  }
+
+  private hide() {
+    // Show original content
+    if (this.originalElement) {
+      this.originalElement.style.display = 'block';
+    }
+
+    // Hide inline editor
+    const editor = document.getElementById('inline-editor');
+    if (editor) {
+      editor.style.display = 'none';
+    }
+
+    // Clean up editor
+    if (this.view) {
+      this.view.destroy();
+      this.view = null;
+    }
+  }
+
+  private async save() {
+    if (!this.view) return;
+
+    const statusEl = document.getElementById('inline-editor-status');
+    if (statusEl) statusEl.textContent = 'Saving...';
+
+    try {
+      // Convert ProseMirror doc back to markdown
+      const markdown = defaultMarkdownSerializer.serialize(this.view.state.doc);
+      
+      // Update file via GitHub API
+      await githubService.updateFile(
+        this.filePath,
+        markdown,
+        this.sha,
+        `Update ${this.filePath} via inline editor`
+      );
+
+      if (statusEl) statusEl.textContent = 'Saved successfully!';
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
+    } catch (error) {
+      console.error('Save failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      if (statusEl) statusEl.textContent = `Error: ${message}`;
+    }
+  }
+
+  private cancel() {
+    this.hide();
+    
+    // Remove edit parameter from URL
+    const url = new URL(window.location.href);
+    url.searchParams.delete('edit');
+    window.history.replaceState({}, '', url.toString());
+  }
+}
+
+// Global inline editor manager
+(window as any).inlineEditorManager = new InlineEditorManager();
+</script>
+
+<style>
+  .inline-editor {
+    margin: 2rem 0;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--background);
+  }
+
+  .editor-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--background-subtle);
+    border-radius: 8px 8px 0 0;
+  }
+
+  .editor-status {
+    color: var(--text-secondary);
+    font-size: 0.9em;
+    min-height: 1.2em;
+  }
+
+  .editor-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .btn {
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: all 0.15s ease;
+  }
+
+  .btn-primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+
+  .btn-primary:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+  }
+
+  .btn-secondary {
+    background: var(--background);
+    color: var(--text-primary);
+  }
+
+  .btn-secondary:hover {
+    background: var(--background-subtle);
+  }
+
+  .editor-content {
+    padding: 1.5rem;
+    min-height: 400px;
+  }
+
+  .editor-content :global(.ProseMirror) {
+    outline: none;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    min-height: 300px;
+    font-family: Georgia, serif;
+    line-height: 1.6;
+    background: var(--background);
+  }
+
+  .editor-content :global(.ProseMirror:focus) {
+    border-color: var(--accent);
+  }
+
+  .editor-content :global(.ProseMirror p) {
+    margin: 1em 0;
+  }
+
+  .editor-content :global(.ProseMirror h1),
+  .editor-content :global(.ProseMirror h2),
+  .editor-content :global(.ProseMirror h3) {
+    font-weight: 400;
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+  }
+
+  @media (max-width: 768px) {
+    .editor-header {
+      flex-direction: column;
+      gap: 1rem;
+      text-align: center;
+    }
+    
+    .editor-content {
+      padding: 1rem;
+    }
+  }
+</style>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import EditButton from '../../components/EditButton.astro';
 import Editor from '../../components/Editor.astro';
+import InlineEditor from '../../components/InlineEditor.astro';
 import { buildBacklinks, generateBacklinksHTML } from '../../utils/backlinks.ts';
 
 export async function getStaticPaths() {
@@ -57,6 +58,9 @@ const filePath = `src/content/blog/${post.slug}.md`;
           <Content />
         </div>
         
+        <!-- Inline Editor -->
+        <InlineEditor filePath={filePath} />
+        
         <!-- Backlinks section -->
         {backlinksHTML && (
           <div set:html={backlinksHTML} />
@@ -72,6 +76,28 @@ const filePath = `src/content/blog/${post.slug}.md`;
   <!-- Editor modal -->
   <Editor content="" filePath={filePath} />
 </Layout>
+
+<script define:vars={{ filePath }}>
+  // Initialize inline editor if edit mode is active
+  function initInlineEditorIfNeeded() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const editMode = urlParams.get('edit') === 'true';
+    
+    if (editMode && (window as any).inlineEditorManager) {
+      // Small delay to ensure all components are loaded
+      setTimeout(() => {
+        (window as any).inlineEditorManager.init(filePath);
+      }, 200);
+    }
+  }
+
+  // Initialize when DOM is loaded
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initInlineEditorIfNeeded);
+  } else {
+    initInlineEditorIfNeeded();
+  }
+</script>
 
 <style>
   .post {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -77,16 +77,16 @@ const filePath = `src/content/blog/${post.slug}.md`;
   <Editor content="" filePath={filePath} />
 </Layout>
 
-<script define:vars={{ filePath }}>
+<script define:vars={{ filePath }} is:inline>
   // Initialize inline editor if edit mode is active
   function initInlineEditorIfNeeded() {
     const urlParams = new URLSearchParams(window.location.search);
     const editMode = urlParams.get('edit') === 'true';
     
-    if (editMode && (window as any).inlineEditorManager) {
+    if (editMode && window.inlineEditorManager) {
       // Small delay to ensure all components are loaded
       setTimeout(() => {
-        (window as any).inlineEditorManager.init(filePath);
+        window.inlineEditorManager.init(filePath);
       }, 200);
     }
   }

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -95,16 +95,16 @@ const filePath = `projects/${slug}.md`;
   <Editor content="" filePath={filePath} />
 </Layout>
 
-<script define:vars={{ filePath }}>
+<script define:vars={{ filePath }} is:inline>
   // Initialize inline editor if edit mode is active
   function initInlineEditorIfNeeded() {
     const urlParams = new URLSearchParams(window.location.search);
     const editMode = urlParams.get('edit') === 'true';
     
-    if (editMode && (window as any).inlineEditorManager) {
+    if (editMode && window.inlineEditorManager) {
       // Small delay to ensure all components are loaded
       setTimeout(() => {
-        (window as any).inlineEditorManager.init(filePath);
+        window.inlineEditorManager.init(filePath);
       }, 200);
     }
   }

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import EditButton from '../../components/EditButton.astro';
 import Editor from '../../components/Editor.astro';
+import InlineEditor from '../../components/InlineEditor.astro';
 import fs from 'fs';
 import path from 'path';
 import { buildBacklinks, generateBacklinksHTML } from '../../utils/backlinks.ts';
@@ -76,6 +77,9 @@ const filePath = `projects/${slug}.md`;
       
       <div class="project-content" set:html={htmlContent} />
       
+      <!-- Inline Editor -->
+      <InlineEditor filePath={filePath} />
+      
       <!-- Backlinks section -->
       {backlinksHTML && (
         <div set:html={backlinksHTML} />
@@ -90,6 +94,28 @@ const filePath = `projects/${slug}.md`;
   <!-- Editor modal -->
   <Editor content="" filePath={filePath} />
 </Layout>
+
+<script define:vars={{ filePath }}>
+  // Initialize inline editor if edit mode is active
+  function initInlineEditorIfNeeded() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const editMode = urlParams.get('edit') === 'true';
+    
+    if (editMode && (window as any).inlineEditorManager) {
+      // Small delay to ensure all components are loaded
+      setTimeout(() => {
+        (window as any).inlineEditorManager.init(filePath);
+      }, 200);
+    }
+  }
+
+  // Initialize when DOM is loaded
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initInlineEditorIfNeeded);
+  } else {
+    initInlineEditorIfNeeded();
+  }
+</script>
 
 <style>
   .project {


### PR DESCRIPTION
This PR implements a smoother editing experience by replacing prominent edit buttons with URL-based edit mode and inline editing.

## Changes
- Fixed save/cancel button functionality by adding missing event listeners
- Implemented URL-based edit mode trigger (?edit=true)
- Created InlineEditor component for seamless inline editing
- Added keyboard shortcuts (Ctrl+S to save, Escape to cancel)
- Integrated with both blog and project pages
- Resolved all TypeScript build errors

## Usage
To edit any page, add `?edit=true` to the URL. The editor will automatically open inline.

Fixes #18

Generated with [Claude Code](https://claude.ai/code)